### PR TITLE
Handle 100s of references to be deleted when a PR closes.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -181,7 +181,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chetter-app"
-version = "0.1.0"
+version = "0.0.3"
 dependencies = [
  "async-trait",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chetter-app"
-version = "0.1.0"
+version = "0.0.3"
 edition = "2021"
 
 [dependencies]

--- a/src/error.rs
+++ b/src/error.rs
@@ -10,6 +10,7 @@ pub enum ChetterError {
     JSONWebTokenError(jsonwebtoken::errors::Error),
     Octocrab(octocrab::Error),
     TOMLParseError(toml::de::Error),
+    JoinError(tokio::task::JoinError),
 }
 
 impl From<std::io::Error> for ChetterError {
@@ -36,6 +37,12 @@ impl From<octocrab::Error> for ChetterError {
     }
 }
 
+impl From<tokio::task::JoinError> for ChetterError {
+    fn from(error: tokio::task::JoinError) -> Self {
+        Self::JoinError(error)
+    }
+}
+
 impl std::error::Error for ChetterError {}
 
 impl std::fmt::Display for ChetterError {
@@ -46,6 +53,7 @@ impl std::fmt::Display for ChetterError {
             ChetterError::JSONWebTokenError(e) => write!(f, "{}", e),
             ChetterError::Octocrab(e) => write!(f, "{}", e),
             ChetterError::TOMLParseError(e) => write!(f, "{}", e),
+            ChetterError::JoinError(e) => write!(f, "{}", e),
         }
     }
 }


### PR DESCRIPTION
1. We weren't paginating the matching refs
2. We took way too long deleting a single reference at a time and hit a 10s timeout on responding to GitHub.